### PR TITLE
Added red border color option to Card component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 
 node_modules
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.144",
+  "version": "0.0.145",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.143",
+  "version": "0.0.144",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.144",
+  "version": "0.0.145",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.143",
+  "version": "0.0.144",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -44,6 +44,7 @@ class Card extends React.Component {
       data,
       isExpanded,
       borderType,
+      borderColorRed,
       type,
       minWidth,
     } = this.props;
@@ -51,6 +52,7 @@ class Card extends React.Component {
     const cardStyle = cx(style.card, {
       [style.condensed]: type === cardTypes.CONDENSED,
       [style.borderDashed]: borderType === borderTypes.DASHED,
+      [style.borderColorRed]: borderColorRed,
       [style.isExpanded]: isExpanded,
     });
 
@@ -119,6 +121,7 @@ Card.propTypes = {
   type: PropTypes.oneOf([cardTypes.REGULAR, cardTypes.CONDENSED]),
   onClick: PropTypes.func,
   borderType: PropTypes.string,
+  borderColorRed: PropTypes.bool,
   expandedComponent: PropTypes.node,
   isExpanded: PropTypes.bool,
   minWidth: PropTypes.number,

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -12,6 +12,7 @@ const cardTypes = {
   CONDENSED: 'condensed',
 };
 const borderTypes = { DASHED: 'dashed' };
+const borderColors = { RED: 'red' };
 
 class Card extends React.Component {
   constructor() {
@@ -44,7 +45,7 @@ class Card extends React.Component {
       data,
       isExpanded,
       borderType,
-      borderColorRed,
+      borderColor,
       type,
       minWidth,
     } = this.props;
@@ -52,7 +53,7 @@ class Card extends React.Component {
     const cardStyle = cx(style.card, {
       [style.condensed]: type === cardTypes.CONDENSED,
       [style.borderDashed]: borderType === borderTypes.DASHED,
-      [style.borderColorRed]: borderColorRed,
+      [style.borderColorRed]: borderColor === borderColors.RED,
       [style.isExpanded]: isExpanded,
     });
 

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -12,7 +12,7 @@ const cardTypes = {
   CONDENSED: 'condensed',
 };
 const borderTypes = { DASHED: 'dashed' };
-const borderColors = { RED: 'red' };
+export const borderColors = { RED: 'red' };
 
 class Card extends React.Component {
   constructor() {
@@ -53,7 +53,7 @@ class Card extends React.Component {
     const cardStyle = cx(style.card, {
       [style.condensed]: type === cardTypes.CONDENSED,
       [style.borderDashed]: borderType === borderTypes.DASHED,
-      [style.borderColorRed]: borderColor === borderColors.RED,
+      [style.borderRed]: borderColor === borderColors.RED,
       [style.isExpanded]: isExpanded,
     });
 
@@ -122,7 +122,7 @@ Card.propTypes = {
   type: PropTypes.oneOf([cardTypes.REGULAR, cardTypes.CONDENSED]),
   onClick: PropTypes.func,
   borderType: PropTypes.string,
-  borderColorRed: PropTypes.bool,
+  borderColor: PropTypes.oneOf([borderColors.RED]),
   expandedComponent: PropTypes.node,
   isExpanded: PropTypes.bool,
   minWidth: PropTypes.number,

--- a/src/components/Card/style.scss
+++ b/src/components/Card/style.scss
@@ -34,7 +34,7 @@
   border: 1px dashed $cBorder;
 }
 
-.borderColorRed {
+.borderRed {
   border-color: $cRed70;
 }
 

--- a/src/components/Card/style.scss
+++ b/src/components/Card/style.scss
@@ -34,6 +34,10 @@
   border: 1px dashed $cBorder;
 }
 
+.borderColorRed {
+  border-color: $cRed70;
+}
+
 .top {
   display: flex;
   justify-content: space-between;

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -14,11 +14,16 @@ class CollapsibleCard extends Component {
     expandableText: PropTypes.node,
     children: PropTypes.node.isRequired,
     styleColor: PropTypes.oneOf([styleColors.RED]),
+    isCollapsed: PropTypes.bool,
     disabled: PropTypes.bool,
   };
 
+  static defaultProps = {
+    isCollapsed: false,
+  }
+
   state = {
-    shouldDisplayCard: false,
+    shouldDisplayCard: !this.props.isCollapsed,
   }
 
   onClick = () => {

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+// Components
+import Card from '../Card/Card';
+
+// Style
+import style from './style.scss';
+
+const styleColors = { RED: 'red' };
+
+class CollapsibleCard extends Component {
+  state = {
+    displayCard: false,
+  }
+
+  onClick = () => {
+    this.setState({ displayCard: !this.state.displayCard });
+  }
+
+  render() {
+    const {
+      headerText,
+      expandableText,
+      children,
+      styleColor,
+      disabled,
+    } = this.props;
+
+    const {
+      displayCard,
+    } = this.state;
+
+    const collapsibleCardStyle = cx(
+      style.collapsibleCard,
+      {
+        [style.styleColorRed]: styleColor === styleColors.RED,
+      }
+    );
+
+    return (
+      <div className={collapsibleCardStyle}>
+        <div className={style.cardHeader}>
+          {headerText}
+          {!disabled && (
+            <div className={style.textLink} onClick={this.onClick}>
+              <b>{expandableText}</b>
+              <div
+                className={
+                  ((displayCard) ? style.textLinkArrowUp : style.textLinkArrowDown )
+                }
+              />
+            </div>
+          )}
+        </div>
+        {!disabled &&
+          displayCard && (
+            <Card borderColor={styleColor}>
+              {children}
+            </Card>
+        )}
+      </div>
+    );
+  }
+}
+
+CollapsibleCard.defaultProps = {};
+
+CollapsibleCard.propTypes = {
+  headerText: PropTypes.node.isRequired,
+  expandableText: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  styleColor: PropTypes.string,
+  disabled: PropTypes.bool,
+};
+
+CollapsibleCard.displayName = 'Plasma@CollapsibleCard';
+
+export default CollapsibleCard;

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -3,20 +3,26 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 // Components
-import Card from '../Card/Card';
+import Card, { borderColors as styleColors } from '../Card/Card';
 
 // Style
 import style from './style.scss';
 
-const styleColors = { RED: 'red' };
-
 class CollapsibleCard extends Component {
+  static propTypes = {
+    headerText: PropTypes.node.isRequired,
+    expandableText: PropTypes.node,
+    children: PropTypes.node.isRequired,
+    styleColor: PropTypes.oneOf([styleColors.RED]),
+    disabled: PropTypes.bool,
+  };
+
   state = {
-    displayCard: false,
+    shouldDisplayCard: false,
   }
 
   onClick = () => {
-    this.setState({ displayCard: !this.state.displayCard });
+    this.setState(prevState => ({ shouldDisplayCard: !prevState.shouldDisplayCard }));
   }
 
   render() {
@@ -29,7 +35,7 @@ class CollapsibleCard extends Component {
     } = this.props;
 
     const {
-      displayCard,
+      shouldDisplayCard,
     } = this.state;
 
     const collapsibleCardStyle = cx(
@@ -45,18 +51,16 @@ class CollapsibleCard extends Component {
           {headerText}
           {!disabled && (
             <div className={style.textLink} onClick={this.onClick}>
-              <b>{expandableText}</b>
+              {expandableText}
               <div
-                className={
-                  ((displayCard) ? style.textLinkArrowUp : style.textLinkArrowDown)
-                }
+                className={shouldDisplayCard ? style.textLinkArrowUp : style.textLinkArrowDown}
               />
             </div>
           )}
         </div>
         {!disabled &&
-          displayCard && (
-            <Card borderColor={(styleColor === styleColors.RED) && styleColor}>
+          shouldDisplayCard && (
+            <Card borderColor={styleColor}>
               {children}
             </Card>
         )}
@@ -64,16 +68,6 @@ class CollapsibleCard extends Component {
     );
   }
 }
-
-CollapsibleCard.defaultProps = {};
-
-CollapsibleCard.propTypes = {
-  headerText: PropTypes.node.isRequired,
-  expandableText: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  styleColor: PropTypes.string,
-  disabled: PropTypes.bool,
-};
 
 CollapsibleCard.displayName = 'Plasma@CollapsibleCard';
 

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -11,7 +11,7 @@ import style from './style.scss';
 class CollapsibleCard extends Component {
   static propTypes = {
     headerText: PropTypes.node.isRequired,
-    expandableText: PropTypes.node,
+    collapsibleText: PropTypes.node,
     children: PropTypes.node.isRequired,
     styleColor: PropTypes.oneOf([styleColors.RED]),
     isCollapsed: PropTypes.bool,
@@ -33,7 +33,7 @@ class CollapsibleCard extends Component {
   render() {
     const {
       headerText,
-      expandableText,
+      collapsibleText,
       children,
       styleColor,
       disabled,
@@ -43,12 +43,9 @@ class CollapsibleCard extends Component {
       shouldDisplayCard,
     } = this.state;
 
-    const collapsibleCardStyle = cx(
-      style.collapsibleCard,
-      {
-        [style.styleColorRed]: styleColor === styleColors.RED,
-      }
-    );
+    const collapsibleCardStyle = cx(style.collapsibleCard, {
+      [style.styleColorRed]: styleColor === styleColors.RED,
+    });
 
     return (
       <div className={collapsibleCardStyle}>
@@ -56,7 +53,7 @@ class CollapsibleCard extends Component {
           {headerText}
           {!disabled && (
             <div className={style.textLink} onClick={this.onClick}>
-              {expandableText}
+              {collapsibleText}
               <div
                 className={shouldDisplayCard ? style.textLinkArrowUp : style.textLinkArrowDown}
               />

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -48,7 +48,7 @@ class CollapsibleCard extends Component {
               <b>{expandableText}</b>
               <div
                 className={
-                  ((displayCard) ? style.textLinkArrowUp : style.textLinkArrowDown )
+                  ((displayCard) ? style.textLinkArrowUp : style.textLinkArrowDown)
                 }
               />
             </div>

--- a/src/components/CollapsibleCard/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard/CollapsibleCard.jsx
@@ -56,7 +56,7 @@ class CollapsibleCard extends Component {
         </div>
         {!disabled &&
           displayCard && (
-            <Card borderColor={styleColor}>
+            <Card borderColor={(styleColor === styleColors.RED) && styleColor}>
               {children}
             </Card>
         )}

--- a/src/components/CollapsibleCard/style.scss
+++ b/src/components/CollapsibleCard/style.scss
@@ -1,0 +1,52 @@
+@import '../../styles/base';
+
+.collapsibleCard {
+  .cardHeader {
+    min-height: 20px;
+    background: $cGray600;
+    border: 1px solid $cBorder;
+    color: $cBlack30;
+    padding: 5px;
+    border-top-right-radius: 2px;
+    border-top-left-radius: 2px;
+  }
+
+  .textLink {
+    margin-left: 10px;
+    float: right;
+  }
+
+  .textLinkArrowUp, .textLinkArrowDown {
+    display: inline-block;
+    margin-left: 5px;
+    margin-right: 5px;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+  }
+
+  .textLinkArrowUp {
+    border-bottom: 5px solid $cBlack30;
+  }
+
+  .textLinkArrowDown {
+    border-top: 5px solid $cBlack30;
+  }
+}
+
+.styleColorRed {
+  .cardHeader {
+    background: $cRed50;
+    border-color: $cRed70;
+    color: $cWhite;
+  }
+
+  .textLinkArrowUp {
+    border-bottom-color: $cWhite;
+  }
+
+  .textLinkArrowDown {
+    border-top-color: $cWhite;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import Button from './components/Button/Button';
 import Card from './components/Card/Card';
 import Checkbox from './components/Checkbox/Checkbox';
+import CollapsibleCard from './components/CollapsibleCard/CollapsibleCard';
 import OverflowMenu from './components/OverflowMenu/OverflowMenu';
 import Header from './components/Header/Header';
 import Icon from './components/Icon/Icon';
@@ -54,6 +55,7 @@ Plasma.Icon = Icon;
 Plasma.Text = Text;
 Plasma.Card = Card;
 Plasma.Checkbox = Checkbox;
+Plasma.CollapsibleCard = CollapsibleCard;
 Plasma.SegmentedCard = SegmentedCard;
 Plasma.Button = Button;
 Plasma.TextInput = TextInput;
@@ -95,6 +97,7 @@ export {
   Text,
   Card,
   Checkbox,
+  CollapsibleCard,
   SegmentedCard,
   Button,
   TextInput,

--- a/src/tests/__tests__/Card.react-test.js
+++ b/src/tests/__tests__/Card.react-test.js
@@ -99,7 +99,7 @@ describe('Card Component unit', () => {
   });
 
   test('red border color', () => {
-    const component = shallow(<Card borderColorRed>Test Red Card</Card>);
+    const component = shallow(<Card borderColor="red">Test Red Card</Card>);
     expect(component.is('.borderColorRed')).toBe(true);
   });
 });

--- a/src/tests/__tests__/Card.react-test.js
+++ b/src/tests/__tests__/Card.react-test.js
@@ -95,11 +95,11 @@ describe('Card Component unit', () => {
 
   test('no red border color', () => {
     const component = shallow(<Card>Test Card</Card>);
-    expect(component.is('.borderColorRed')).toBe(false);
+    expect(component.is('.borderRed')).toBe(false);
   });
 
   test('red border color', () => {
     const component = shallow(<Card borderColor="red">Test Red Card</Card>);
-    expect(component.is('.borderColorRed')).toBe(true);
+    expect(component.is('.borderRed')).toBe(true);
   });
 });

--- a/src/tests/__tests__/Card.react-test.js
+++ b/src/tests/__tests__/Card.react-test.js
@@ -92,4 +92,14 @@ describe('Card Component unit', () => {
     );
     expect(component.find('.action')).toHaveLength(2);
   });
+
+  test('no red border color', () => {
+    const component = shallow(<Card>Test Card</Card>);
+    expect(component.is('.borderColorRed')).toBe(false);
+  });
+
+  test('red border color', () => {
+    const component = shallow(<Card borderColorRed>Test Red Card</Card>);
+    expect(component.is('.borderColorRed')).toBe(true);
+  });
 });

--- a/src/tests/__tests__/CollapsibleCard.react-test.js
+++ b/src/tests/__tests__/CollapsibleCard.react-test.js
@@ -11,7 +11,7 @@ describe('CollapsibleCard Component unit', () => {
     component = shallow(
       <CollapsibleCard
         headerText="Header Text"
-        expandableText="more"
+        collapsibleText="more"
       >
         Test Card
       </CollapsibleCard>
@@ -74,7 +74,7 @@ describe('CollapsibleCard Component unit', () => {
       component = shallow(
         <CollapsibleCard
           headerText="Header Text"
-          expandableText="more"
+          collapsibleText="more"
           disabled
         >
           Test Card

--- a/src/tests/__tests__/CollapsibleCard.react-test.js
+++ b/src/tests/__tests__/CollapsibleCard.react-test.js
@@ -1,0 +1,90 @@
+/* eslint-disable */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CollapsibleCard from '../../components/CollapsibleCard/CollapsibleCard';
+
+describe('CollapsibleCard Component unit', () => {
+  let component;
+  beforeEach(() => {
+    component = shallow(
+      <CollapsibleCard
+        headerText="Header Text"
+        expandableText="more"
+      >
+        Test Card
+      </CollapsibleCard>
+    );
+  })
+
+  test('displays header text', () => {
+    expect(component.contains('Header Text')).toBe(true);
+  });
+
+  test('displays expandable text', () => {
+    expect(component.contains('more')).toBe(true);
+  });
+
+  test('displays arrow down', () => {
+    expect(component.find('.textLinkArrowDown').exists()).toBe(true);
+  });
+
+  test('no red border color', () => {
+    expect(component.is('.styleColorRed')).toBe(false);
+  });
+
+  test('red border color', () => {
+    component = shallow(
+      <CollapsibleCard
+        headerText="Header Text"
+        styleColor="red"
+      >
+        Test Red Card
+      </CollapsibleCard>
+    );
+    expect(component.is('.styleColorRed')).toBe(true);
+  });
+
+  describe('when clicked ', () => {
+    test('displays children', () => {
+      component.find('.textLink').simulate('click');
+      expect(component.contains('Test Card')).toBe(true);
+    });
+
+    test('displays arrow up', () => {
+      component.find('.textLink').simulate('click');
+      expect(component.find('.textLinkArrowUp').exists()).toBe(true);
+    });
+  });
+
+  describe('when disabled ', () => {
+    beforeEach(() => {
+      component = shallow(
+        <CollapsibleCard
+          headerText="Header Text"
+          expandableText="more"
+          disabled
+        >
+          Test Card
+        </CollapsibleCard>
+      );
+    });
+
+    test('displays header text', () => {
+      expect(component.contains('Header Text')).toBe(true);
+    });
+
+    test('does not display arrow down', () => {
+      expect(component.find('.textLinkArrowDown').exists()).toBe(false);
+    });
+
+    test('does not display arrow up', () => {
+      expect(component.find('.textLinkArrowUp').exists()).toBe(false);
+    });
+
+    test('does not display children', () => {
+      expect(component.contains('Test Card')).toBe(false);
+    });
+  });
+});

--- a/src/tests/__tests__/CollapsibleCard.react-test.js
+++ b/src/tests/__tests__/CollapsibleCard.react-test.js
@@ -26,8 +26,8 @@ describe('CollapsibleCard Component unit', () => {
     expect(component.contains('more')).toBe(true);
   });
 
-  test('displays arrow down', () => {
-    expect(component.find('.textLinkArrowDown').exists()).toBe(true);
+  test('displays arrow up', () => {
+    expect(component.find('.textLinkArrowUp').exists()).toBe(true);
   });
 
   test('no red border color', () => {
@@ -46,15 +46,26 @@ describe('CollapsibleCard Component unit', () => {
     expect(component.is('.styleColorRed')).toBe(true);
   });
 
+  test('displays children', () => {
+    component = shallow(
+      <CollapsibleCard
+        headerText="Header Text"
+      >
+        Test Card
+      </CollapsibleCard>
+    );
+    expect(component.contains('Test Card')).toBe(true);
+  });
+
   describe('when clicked ', () => {
-    test('displays children', () => {
+    test('does not display children', () => {
       component.find('.textLink').simulate('click');
-      expect(component.contains('Test Card')).toBe(true);
+      expect(component.contains('Test Card')).toBe(false);
     });
 
-    test('displays arrow up', () => {
+    test('displays arrow down', () => {
       component.find('.textLink').simulate('click');
-      expect(component.find('.textLinkArrowUp').exists()).toBe(true);
+      expect(component.find('.textLinkArrowDown').exists()).toBe(true);
     });
   });
 

--- a/stories/Card.js
+++ b/stories/Card.js
@@ -12,6 +12,11 @@ storiesOf('Card', module)
       <Card>Hello</Card>
     </div>
   ))
+  .add('red border color', () => (
+    <div style={{ display: 'flex' }}>
+      <Card borderColorRed>Hello</Card>
+    </div>
+  ))
   .add('min width', () => (
     <div style={{ display: 'flex' }}>
       <Card minWidth={200}>Hello</Card>

--- a/stories/Card.js
+++ b/stories/Card.js
@@ -14,7 +14,7 @@ storiesOf('Card', module)
   ))
   .add('red border color', () => (
     <div style={{ display: 'flex' }}>
-      <Card borderColorRed>Hello</Card>
+      <Card borderColor="red">Hello</Card>
     </div>
   ))
   .add('min width', () => (

--- a/stories/CollapsibleCard.jsx
+++ b/stories/CollapsibleCard.jsx
@@ -16,7 +16,7 @@ storiesOf('CollapsibleCard', module)
     <div style={{ display: 'flex' }}>
       <CollapsibleCard
         headerText="Header Text"
-        expandableText="more"
+        collapsibleText="more"
       >
         Hello
       </CollapsibleCard>

--- a/stories/CollapsibleCard.jsx
+++ b/stories/CollapsibleCard.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import CollapsibleCard from '../src/components/CollapsibleCard/CollapsibleCard';

--- a/stories/CollapsibleCard.jsx
+++ b/stories/CollapsibleCard.jsx
@@ -1,0 +1,46 @@
+/* eslint-disable */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import CollapsibleCard from '../src/components/CollapsibleCard/CollapsibleCard';
+
+storiesOf('CollapsibleCard', module)
+  .add('default', () => (
+    <div style={{ display: 'flex' }}>
+      <CollapsibleCard
+        headerText="Header Text"
+      >
+        Hello
+      </CollapsibleCard>
+    </div>
+  ))
+  .add('expandable text', () => (
+    <div style={{ display: 'flex' }}>
+      <CollapsibleCard
+        headerText="Header Text"
+        expandableText="more"
+      >
+        Hello
+      </CollapsibleCard>
+    </div>
+  ))
+  .add('red style color', () => (
+    <div style={{ display: 'flex' }}>
+      <CollapsibleCard
+        headerText="Header Text"
+        styleColor="red"
+      >
+        Hello
+      </CollapsibleCard>
+    </div>
+  ))
+  .add('disabled', () => (
+    <div style={{ display: 'flex' }}>
+      <CollapsibleCard
+        headerText="Header Text"
+        disabled
+      >
+        Hello
+      </CollapsibleCard>
+    </div>
+  ));

--- a/stories/CollapsibleCard.jsx
+++ b/stories/CollapsibleCard.jsx
@@ -22,6 +22,16 @@ storiesOf('CollapsibleCard', module)
       </CollapsibleCard>
     </div>
   ))
+  .add('is collapsed', () => (
+    <div style={{ display: 'flex' }}>
+      <CollapsibleCard
+        headerText="Header Text"
+        isCollapsed
+      >
+        Hello
+      </CollapsibleCard>
+    </div>
+  ))
   .add('red style color', () => (
     <div style={{ display: 'flex' }}>
       <CollapsibleCard

--- a/stories/index.js
+++ b/stories/index.js
@@ -26,3 +26,4 @@ import Toggle from './Toggle';
 import Welcome from './Welcome';
 import Modal from './Modal';
 import Card from './Card';
+import CollapsibleCard from './CollapsibleCard';


### PR DESCRIPTION
This change relates to ban more information feature: https://jira.we.co/browse/CMOS-3542

Card Red Border:
![storybook_card_redborder](https://user-images.githubusercontent.com/37114697/38031406-216b2258-3269-11e8-95e3-95e30011a280.png)

Collapsible Card:
![screen shot 2018-03-29 at 11 13 44 am](https://user-images.githubusercontent.com/37114697/38097032-4e3af414-3342-11e8-9439-6e7813dc9632.png)

