### PR TITLE
Fixing flow Data type

### DIFF
--- a/src/tests/__tests__/Toggle.react-test.js
+++ b/src/tests/__tests__/Toggle.react-test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Toggle from '../../components/Toggle/Toggle';
 import renderer from 'react-test-renderer';
 import { shallow, mount } from 'enzyme';
+import uuidv4 from 'uuid/v4';
 
 describe('Toggle Component', () => {
   test('render', () => {
@@ -71,5 +72,23 @@ describe('Toggle Component', () => {
       .simulate('keydown', { keyCode: 13 });
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith('one', 0);
+  });
+
+  test('data attributes are added', () => {
+    const items = [
+      {
+        label: 'one',
+        title: 'One',
+      },
+    ];
+    const dataAttributes = {
+      qa: 'toggle',
+      id: uuidv4(),
+    };
+    const component = shallow(<Toggle items={items} data={dataAttributes} />);
+
+    Object.entries(dataAttributes).forEach(([key, value]) =>
+      expect(component.prop(`data-${key}`)).toEqual(value)
+    );
   });
 });

--- a/src/types.js
+++ b/src/types.js
@@ -1,7 +1,6 @@
 // @flow
 export type Data = {
-  key: string,
-  value: string,
+  [key: string]: string,
 };
 
 export type GlobalAttributes = {|


### PR DESCRIPTION
`Data` should receive a hash of key-value pairs (see `getDataAttrs` implementation). The previous type yielded a `data-key` and `data-value` attributes, instead of `data-${key}="${value}`.

The following fix is backward compatible, but will allow new code to leverage `data-` attributes.