### PR TITLE
Toggle - disabled items shouldn't call onChange()

### DIFF
--- a/src/components/Toggle/Toggle.jsx
+++ b/src/components/Toggle/Toggle.jsx
@@ -33,7 +33,9 @@ class Toggle extends React.Component<Props> {
     onChange: () => {},
   };
   onClick(toggle: Object, index: number) {
-    this.props.onChange(toggle.label, index);
+    if (toggle.disabled !== true) {
+      this.props.onChange(toggle.label, index);
+    }
   }
 
   onKeyDown(event: Object, toggle: Object, index: number) {
@@ -49,7 +51,7 @@ class Toggle extends React.Component<Props> {
           const toggleClasses = cx(style.toggle, {
             [style.active]:
               this.props.selectedIndex === index || this.props.selectedLabel === toggle.label,
-            [style.disabled]: this.props.items[index].disabled,
+            [style.disabled]: toggle.disabled,
             [style.horizontal]: this.props.type === type.HORIZONTAL,
             [style.vertical]: this.props.type === type.VERTICAL,
             [style.small]: this.props.size === type.SMALL,
@@ -63,6 +65,7 @@ class Toggle extends React.Component<Props> {
               className={toggleClasses}
               key={index}
               type={this.props.type}
+              data-state={toggle.disabled ? 'disabled' : 'enabled'}
             >
               {toggle.title}
             </li>

--- a/src/components/Toggle/Toggle.jsx
+++ b/src/components/Toggle/Toggle.jsx
@@ -32,26 +32,26 @@ class Toggle extends React.Component<Props> {
     type: type.HORIZONTAL,
     onChange: () => {},
   };
-  onClick(toggle: Object, index: number) {
-    if (toggle.disabled !== true) {
-      this.props.onChange(toggle.label, index);
+  onClick(item: Object, index: number) {
+    if (item.disabled !== true) {
+      this.props.onChange(item.label, index);
     }
   }
 
-  onKeyDown(event: Object, toggle: Object, index: number) {
+  onKeyDown(event: Object, item: Object, index: number) {
     if (event.keyCode === 13 /* enter */) {
-      this.onClick(toggle, index);
+      this.onClick(item, index);
     }
   }
 
   render() {
     return (
       <ul {...getDataAttrs(this.props.data)} className={style.toggleWrapper} role="tablist">
-        {_.map(this.props.items, (toggle, index) => {
+        {_.map(this.props.items, (item, index) => {
           const toggleClasses = cx(style.toggle, {
             [style.active]:
-              this.props.selectedIndex === index || this.props.selectedLabel === toggle.label,
-            [style.disabled]: toggle.disabled,
+              this.props.selectedIndex === index || this.props.selectedLabel === item.label,
+            [style.disabled]: item.disabled,
             [style.horizontal]: this.props.type === type.HORIZONTAL,
             [style.vertical]: this.props.type === type.VERTICAL,
             [style.small]: this.props.size === type.SMALL,
@@ -60,14 +60,14 @@ class Toggle extends React.Component<Props> {
           return (
             <li
               role="tab"
-              onClick={() => this.onClick(toggle, index)}
-              onKeyDown={event => this.onKeyDown(event, toggle, index)}
+              onClick={() => this.onClick(item, index)}
+              onKeyDown={event => this.onKeyDown(event, item, index)}
               className={toggleClasses}
               key={index}
               type={this.props.type}
-              data-state={toggle.disabled ? 'disabled' : 'enabled'}
+              data-state={item.disabled ? 'disabled' : 'enabled'}
             >
-              {toggle.title}
+              {item.title}
             </li>
           );
         })}

--- a/src/components/Toggle/Toggle.jsx
+++ b/src/components/Toggle/Toggle.jsx
@@ -33,7 +33,7 @@ class Toggle extends React.Component<Props> {
     onChange: () => {},
   };
   onClick(item: Object, index: number) {
-    if (item.disabled !== true) {
+    if (!item.disabled) {
       this.props.onChange(item.label, index);
     }
   }

--- a/src/tests/__tests__/Toggle.react-test.js
+++ b/src/tests/__tests__/Toggle.react-test.js
@@ -24,10 +24,14 @@ describe('Toggle Component', () => {
       },
     ];
     const component = shallow(<Toggle items={items} />);
-    expect(component.find('li')).toHaveLength(2);
+    const options = component.find('li');
+    expect(options).toHaveLength(2);
+    options.forEach(option => {
+      expect(option.prop('data-state')).toEqual('enabled');
+    });
   });
 
-  test('onClick first item', () => {
+  describe('clicks', () => {
     const items = [
       {
         label: 'one',
@@ -36,40 +40,41 @@ describe('Toggle Component', () => {
       {
         label: 'two',
         title: 'Two',
+        disabled: true,
       },
     ];
     const onChange = jest.fn();
     const component = mount(<Toggle items={items} onChange={onChange} />);
-    component
-      .find('li')
-      .first()
-      .simulate('click');
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith('one', 0);
-  });
 
-  test('keydown first item', () => {
-    const items = [
-      {
-        label: 'one',
-        title: 'One',
-      },
-      {
-        label: 'two',
-        title: 'Two',
-      },
-      {
-        label: 'three',
-        title: 'Three',
-      },
-    ];
-    const onChange = jest.fn();
-    const component = mount(<Toggle items={items} onChange={onChange} />);
-    component
-      .find('li')
-      .first()
-      .simulate('keydown', { keyCode: 13 });
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith('one', 0);
+    beforeEach(() => {
+      onChange.mockClear();
+    });
+
+    test('enabled option is clickable', () => {
+      const enabledOptions = component.find('li[data-state="enabled"]');
+      expect(enabledOptions).toHaveLength(1);
+
+      const enabledOption = enabledOptions.first();
+      expect(enabledOption.text()).toEqual(items[0].title);
+
+      enabledOption.simulate('click');
+      expect(onChange).toHaveBeenCalledWith(items[0].label, 0);
+    });
+
+    test('enabled option accepts <enter> keydown', () => {
+      const enabledOption = component.find('li[data-state="enabled"]').first();
+      enabledOption.simulate('keydown', { keyCode: 13 });
+      expect(onChange).toHaveBeenCalledWith(items[0].label, 0);
+    });
+
+    test('disabled options are not clickable', () => {
+      const disabledOptions = component.find('li[data-state="disabled"]');
+      expect(disabledOptions).toHaveLength(1);
+      const disabledOption = disabledOptions.first();
+      expect(disabledOption.text()).toEqual(items[1].title);
+      disabledOption.simulate('click');
+      disabledOption.simulate('keydown', { keyCode: 13 });
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
- Disabled items shouldn't call `onChange()`.
- Add `data-state` property to help test whether the item is enabled or disabled.