### PR TITLE
remove unused style prop and add innerWrapperStyle

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -11,7 +11,7 @@ type Props = {|
   children: Node,
   visible?: boolean,
   onDismiss?: (evt: MouseEvent) => void,
-  style?: { [string]: string | number },
+  innerWrapperStyle: Object,
   minWidth?: string | number,
   maxWidth?: string | number,
   data?: Data,
@@ -28,6 +28,7 @@ class Modal extends React.Component<Props> {
       minWidth = 0,
       maxWidth,
       visible,
+      innerWrapperStyle,
     } = this.props;
 
     if (!visible) {
@@ -37,7 +38,7 @@ class Modal extends React.Component<Props> {
     return (
       <div {...getDataAttrs(data)} className={style.wrapper}>
         <div className={style.innerWrapper}>
-          <div style={{ minWidth, maxWidth }} className={style.card}>
+          <div style={{ minWidth, maxWidth, ...innerWrapperStyle }} className={style.card}>
             <div className={style.content}>
               {title && (
                 <div className={style.top}>

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -11,7 +11,7 @@ type Props = {|
   children: Node,
   visible?: boolean,
   onDismiss?: (evt: MouseEvent) => void,
-  innerWrapperStyle: Object,
+  innerCardStyle: { [string]: string | number },
   minWidth?: string | number,
   maxWidth?: string | number,
   data?: Data,
@@ -28,7 +28,7 @@ class Modal extends React.Component<Props> {
       minWidth = 0,
       maxWidth,
       visible,
-      innerWrapperStyle,
+      innerCardStyle,
     } = this.props;
 
     if (!visible) {
@@ -38,7 +38,7 @@ class Modal extends React.Component<Props> {
     return (
       <div {...getDataAttrs(data)} className={style.wrapper}>
         <div className={style.innerWrapper}>
-          <div style={{ minWidth, maxWidth, ...innerWrapperStyle }} className={style.card}>
+          <div style={{ ...innerCardStyle, minWidth, maxWidth }} className={style.card}>
             <div className={style.content}>
               {title && (
                 <div className={style.top}>


### PR DESCRIPTION
- for our pre-registered guests bulk upload feature, I add to add a learn more link that flip the modal when clicked. In order for it to work, I add to add the ability to add style to the modal inner wrapper.

- I removed the style prop, it was unused.

here is a link to the pr in spacestation using the innerWrapperStyle prop: 
https://github.com/WeConnect/spacestation-web/pull/3873