### PR TITLE
FIX: dependencies warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "lodash": "^4.14.1",
     "marked": "^0.3.6",
     "mkdirp": "^0.5.1",
-    "moment": "2.24.0",
     "node-sass": "^4.9.3",
     "prettier": "1.16.1",
     "proxy-middleware": "^0.15.0",
@@ -114,13 +113,12 @@
     "react-datepicker": "^1.4.0",
     "react-input-autosize": "^1.1.0",
     "react-select": "^2.4.1",
-    "moment": "^2.18.1"
+    "moment": "2.24.0"
   },
   "peerDependencies": {
     "moment": "^2.24",
     "react": "^16.6",
-    "react-dom": "^16.6",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-dom": "^16.6"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -27,6 +27,7 @@ class Search extends Component<Props, State> {
   static defaultProps = {
     placeholder: 'Search...',
     onKeyDown: null,
+    autoFocus: false,
   };
 
   constructor(props: Props) {

--- a/src/tests/__tests__/__snapshots__/Search.react-test.js.snap
+++ b/src/tests/__tests__/__snapshots__/Search.react-test.js.snap
@@ -16,6 +16,7 @@ exports[`Search Component render 1`] = `
       />
     </span>
     <input
+      autoFocus={false}
       className="input"
       disabled={undefined}
       onChange={[Function]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9681,7 +9681,7 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.18.1:
+moment@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Fixes 2 warnings:

#### moment.js
```
warning package.json: "dependencies" has dependency "moment" with range "^2.18.1" that collides with a dependency in "devDependencies" of the same name with version "2.24.0"
warning @wework-dev/plasma@0.0.193: "dependencies" has dependency "moment" with range "^2.18.1" that collides with a dependency in "devDependencies" of the same name with version "2.24.0"
```

#### react-tap-event-plugin
Removed, as it is [deprecated](https://github.com/zilverline/react-tap-event-plugin#deprecated) and not in use by any of the dependencies or plasma itself.