### PR TITLE
Allow Loader to accept classNames or dotColor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
       {
         "allowShortCircuit": true
       }
-    ]
+    ],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["stories/**/*.js?"]}]
   }
 }

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -70,7 +70,7 @@ function Button(props: Props): Node {
     const loaderDotStyle =
       type === Variants.SECONDARY || type === Variants.TERTIARY
         ? { backgroundColor: '#000', opacity: '0.1' }
-        : null;
+        : undefined;
 
     contentComponent = <Loader dotStyle={loaderDotStyle} />;
   } else {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import React, { type Node } from 'react';
 import style from './style.scss';
 import { getDataAttrs } from '../../dataUtils';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 
 type Props = {|
   text?: string,
@@ -16,7 +16,7 @@ type Props = {|
   h5?: boolean,
   h6?: boolean,
   invert?: boolean,
-  style?: { [string]: string },
+  style?: StyleAttributes,
   noMargin?: boolean,
   data?: Data,
 |};

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -4,13 +4,13 @@ import cn from 'classnames';
 import styles from './style.scss';
 
 import { getDataAttrs } from '../../dataUtils';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 
 const defaultImage = 'https://cdn.spacetelescope.org/archives/images/screen/s82e5407.jpg';
 
 type Props = {|
-  style?: { [string]: string },
-  imageStyle?: { [string]: string },
+  style?: StyleAttributes,
+  imageStyle?: StyleAttributes,
   src: string,
   altText?: string,
   data?: Data,

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -6,19 +6,19 @@ import { getDataAttrs } from '../../dataUtils';
 import type { Data } from '../../types';
 
 type Props = {|
-  className?: Object,
+  className?: string,
   dotColor?: string,
-  dotClassName?: Object,
+  dotClassName?: string,
   style?: Object,
-  dotStyle?: ?Object,
+  dotStyle?: Object,
   data?: Data,
 |};
 
 class Loader extends React.Component<Props> {
   render() {
-    const dotStyle = this.props.dotStyle || {};
-    if (this.props.dotColor != null) {
-      dotStyle.backgroundColor = this.props.dotColor;
+    const { dotColor, dotStyle = {} } = this.props;
+    if (dotColor != null) {
+      dotStyle.backgroundColor = dotColor;
     }
 
     return (

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -10,13 +10,17 @@ type Props = {|
   dotColor?: string,
   dotClassName?: string,
   style?: Object,
-  dotStyle?: Object,
+  dotStyle: Object,
   data?: Data,
 |};
 
 class Loader extends React.Component<Props> {
+  static defaultProps = {
+    dotStyle: {},
+  };
+
   render() {
-    const { dotColor, dotStyle = {} } = this.props;
+    const { dotColor, dotStyle } = this.props;
     if (dotColor != null) {
       dotStyle.backgroundColor = dotColor;
     }

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 import cn from 'classnames';
 import style from './style.scss';
 import { getDataAttrs } from '../../dataUtils';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 
 type Props = {|
   className?: string,
   dotColor?: string,
   dotClassName?: string,
-  style?: Object,
-  dotStyle: Object,
+  style?: StyleAttributes,
+  dotStyle: StyleAttributes,
   data?: Data,
 |};
 

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -1,10 +1,14 @@
 // @flow
 import React from 'react';
+import cn from 'classnames';
 import style from './style.scss';
 import { getDataAttrs } from '../../dataUtils';
 import type { Data } from '../../types';
 
 type Props = {|
+  className?: Object,
+  dotColor?: string,
+  dotClassName?: Object,
   style?: Object,
   dotStyle?: ?Object,
   data?: Data,
@@ -12,12 +16,21 @@ type Props = {|
 
 class Loader extends React.Component<Props> {
   render() {
+    const dotStyle = this.props.dotStyle || {};
+    if (this.props.dotColor != null) {
+      dotStyle.backgroundColor = this.props.dotColor;
+    }
+
     return (
-      <div {...getDataAttrs(this.props.data)} className={style.container} style={this.props.style}>
+      <div
+        {...getDataAttrs(this.props.data)}
+        className={cn(style.container, this.props.className)}
+        style={this.props.style}
+      >
         <div className={style.spinner}>
-          <div className={style.bounce1} style={this.props.dotStyle} />
-          <div className={style.bounce2} style={this.props.dotStyle} />
-          <div className={style.bounce3} style={this.props.dotStyle} />
+          <div className={cn(style.bounce2, this.props.dotClassName)} style={dotStyle} />
+          <div className={cn(style.bounce3, this.props.dotClassName)} style={dotStyle} />
+          <div className={cn(style.bounce1, this.props.dotClassName)} style={dotStyle} />
         </div>
       </div>
     );

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -4,7 +4,7 @@ import cn from 'classnames';
 import style from './style.scss';
 import Header from '../Header/Header';
 import { getDataAttrs } from '../../dataUtils';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 
 type Props = {|
   title?: string,
@@ -12,7 +12,7 @@ type Props = {|
   children: Node,
   visible?: boolean,
   onDismiss?: (evt: MouseEvent) => void,
-  innerCardStyle: { [string]: string | number },
+  innerCardStyle: StyleAttributes,
   minWidth?: string | number,
   maxWidth?: string | number,
   data?: Data,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -3,7 +3,7 @@ import { pick, keys, forEach, isNull, get, map, includes, isEqual, find } from '
 import React from 'react';
 import cx from 'classnames';
 import { getDataAttrs } from '../../dataUtils';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 import Icon from '../Icon/Icon';
 import upArrow from '../../icons/upArrow';
 import downArrow from '../../icons/downArrow';
@@ -21,7 +21,7 @@ type Props = {|
   selectedColumnKey?: string,
   spanMap?: Object,
   stickAt?: number,
-  style?: { [string]: string },
+  style?: StyleAttributes,
   data?: Data,
   sort: { key: string, order: string },
 |};

--- a/src/components/Text/Text.jsx
+++ b/src/components/Text/Text.jsx
@@ -2,14 +2,14 @@
 import React, { type Node } from 'react';
 import cx from 'classnames';
 import style from './style.scss';
-import type { Data } from '../../types';
+import type { Data, StyleAttributes } from '../../types';
 import { getDataAttrs } from '../../dataUtils';
 
 export type Props = {|
   children: Node,
   data?: Data,
   large?: boolean,
-  style?: { [string]: string | number },
+  style?: StyleAttributes,
   type?: string,
 |};
 

--- a/src/components/layout/FormField/FormField.jsx
+++ b/src/components/layout/FormField/FormField.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
+import type { StyleAttributes } from '../../../types';
 import { getDataAttrs } from '../../../dataUtils';
 import styles from './style.scss';
 import Label from '../../Label/Label.jsx';
@@ -12,7 +13,7 @@ type Props = {|
   displayError?: boolean,
   errorMessage?: string,
   data?: Object,
-  style?: { [string]: string },
+  style?: StyleAttributes,
 |};
 
 const FormField = ({

--- a/src/components/layout/Group/Group.jsx
+++ b/src/components/layout/Group/Group.jsx
@@ -3,14 +3,14 @@ import React, { type Node } from 'react';
 import cx from 'classnames';
 import { map, isArray, toArray } from 'lodash';
 import { getDataAttrs } from '../../../dataUtils';
-import type { Data } from '../../../types';
+import type { Data, StyleAttributes } from '../../../types';
 import style from './style.scss';
 
 type Props = {|
   children: Array<Node>,
   vertical?: boolean,
   layout: Array<Object>,
-  style?: { [string]: string },
+  style?: StyleAttributes,
   data?: Data,
 |};
 

--- a/src/tests/__tests__/Loader.react-test.js
+++ b/src/tests/__tests__/Loader.react-test.js
@@ -10,4 +10,10 @@ describe('Loader Component', () => {
     const component = renderer.create(<Loader />);
     expect(component).toMatchSnapshot();
   });
+
+  test('sets dotColor as the dots background-color', () => {
+    const component = renderer.create(<Loader dotColor="#c1c1c1" />);
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/tests/__tests__/__snapshots__/Loader.react-test.js.snap
+++ b/src/tests/__tests__/__snapshots__/Loader.react-test.js.snap
@@ -9,16 +9,52 @@ exports[`Loader Component render 1`] = `
     className="spinner"
   >
     <div
-      className="bounce1"
-      style={undefined}
-    />
-    <div
       className="bounce2"
-      style={undefined}
+      style={Object {}}
     />
     <div
       className="bounce3"
-      style={undefined}
+      style={Object {}}
+    />
+    <div
+      className="bounce1"
+      style={Object {}}
+    />
+  </div>
+</div>
+`;
+
+exports[`Loader Component sets dotColor as the dots background-color 1`] = `
+<div
+  className="container"
+  style={undefined}
+>
+  <div
+    className="spinner"
+  >
+    <div
+      className="bounce2"
+      style={
+        Object {
+          "backgroundColor": "#c1c1c1",
+        }
+      }
+    />
+    <div
+      className="bounce3"
+      style={
+        Object {
+          "backgroundColor": "#c1c1c1",
+        }
+      }
+    />
+    <div
+      className="bounce1"
+      style={
+        Object {
+          "backgroundColor": "#c1c1c1",
+        }
+      }
     />
   </div>
 </div>

--- a/src/types.js
+++ b/src/types.js
@@ -66,3 +66,5 @@ export type FocusEventHandlers<T: EventTarget = EventTarget> = {|
   onFocus?: SyntheticFocusEventHandler<T>,
   onBlur?: SyntheticFocusEventHandler<T>,
 |};
+
+export type StyleAttributes = { [string]: string | number };

--- a/stories/Loader.js
+++ b/stories/Loader.js
@@ -1,5 +1,0 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import Loader from '../src/components/Loader/Loader';
-
-storiesOf('Loader', module).add('default', () => <Loader />);

--- a/stories/Loader.jsx
+++ b/stories/Loader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Loader from '../src/components/Loader/Loader';
+
+import styles from './style.scss';
+
+storiesOf('Loader', module)
+  .add('default', () => <Loader />)
+  .add('dotColor', () => <Loader dotColor="#ff0000" />)
+  .add('dotClassName', () => <Loader dotClassName={styles.greenDotLoader} />);

--- a/stories/Loader.jsx
+++ b/stories/Loader.jsx
@@ -6,5 +6,6 @@ import styles from './style.scss';
 
 storiesOf('Loader', module)
   .add('default', () => <Loader />)
-  .add('dotColor', () => <Loader dotColor="#ff0000" />)
+  .add('dotStyle', () => <Loader dotStyle={{ backgroundColor: '#c1c1c1' }} />)
+  .add('dotColor', () => <Loader dotColor="#f00" />)
   .add('dotClassName', () => <Loader dotClassName={styles.greenDotLoader} />);

--- a/stories/style.scss
+++ b/stories/style.scss
@@ -1,0 +1,3 @@
+.greenDotLoader {
+  background-color: #00ff00 !important;
+}

--- a/stories/style.scss
+++ b/stories/style.scss
@@ -1,3 +1,3 @@
 .greenDotLoader {
-  background-color: #00ff00 !important;
+  background-color: #0f0 !important;
 }


### PR DESCRIPTION
Adding 3 new properties to `<Loader />`:
- `className` & `dotClassName` which will apply on the wrapper and the dot
```css
.coolDot {
  background-color: #00ff00 !important;
}
```
```jsx
  import styles from './styles.css';

  <Loader dotClassName={styles.coolDot} />
```

- `dotColor` for specifically overriding the dot color.
```jsx
  <Loader dotColor="#c1c1c1" />
```


The `import/no-extraneous-dependencies` rule was set to ignore the `storybook` import on the stories.