### PR TITLE
Table: Allow specifying a classname for rows

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -268,7 +268,7 @@ class Table extends React.Component<Props, State> {
 
         columnComponents.push(
           <td
-            className={cx(style.cell, itemValue.cellClassName, {
+            className={cx(style.cell, {
               [style.condensedCell]: isCondensed,
             })}
             key={headerKey}
@@ -298,7 +298,7 @@ class Table extends React.Component<Props, State> {
           const partialRowColumns = [];
           forEach(spannedHeaderKeys, key => {
             partialRowColumns.push(
-              <td key={key} className={cx(style.cell, itemValue.cellClassName)}>
+              <td key={key} className={style.cell}>
                 {itemValue[spanKey][i][key]}
               </td>
             );

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -268,8 +268,7 @@ class Table extends React.Component<Props, State> {
 
         columnComponents.push(
           <td
-            className={cx({
-              [style.cell]: true,
+            className={cx(style.cell, itemValue.cellClassName, {
               [style.condensedCell]: isCondensed,
             })}
             key={headerKey}
@@ -283,8 +282,7 @@ class Table extends React.Component<Props, State> {
       rowComponents.push(
         <tr
           key={itemIndex}
-          className={cx({
-            [style.row]: true,
+          className={cx(style.row, itemValue.rowClassName, {
             [style.rowDisabled]: isDisabledRow,
             [style.clickable]: clickable,
             [style.highlightable]: highlightable,
@@ -300,7 +298,7 @@ class Table extends React.Component<Props, State> {
           const partialRowColumns = [];
           forEach(spannedHeaderKeys, key => {
             partialRowColumns.push(
-              <td key={key} className={style.cell}>
+              <td key={key} className={cx(style.cell, itemValue.cellClassName)}>
                 {itemValue[spanKey][i][key]}
               </td>
             );
@@ -308,8 +306,7 @@ class Table extends React.Component<Props, State> {
           rowComponents.push(
             <tr
               key={`${itemIndex}.${i}`}
-              className={cx({
-                [style.row]: true,
+              className={cx(style.row, itemValue.rowClassName, {
                 [style.rowDisabled]: isDisabledRow,
                 [style.clickable]: clickable,
                 [style.highlightable]: highlightable,

--- a/stories/Table.js
+++ b/stories/Table.js
@@ -224,15 +224,14 @@ storiesOf('Table', module).add('with condensed column', () => {
   );
 });
 
-storiesOf('Table', module).add('with a styled rows and cols', () => {
+storiesOf('Table', module).add('with styled rows', () => {
   const items = [
     {
       firstname: 'Brad',
       lastname: 'Pitt',
       age: '45',
       sex: 'Male',
-      location: 'Beverly Hills',
-      cellClassName: style.tableCellRed,
+      location: 'Beverly Hills'
     },
     {
       firstname: 'Jennifer',

--- a/stories/Table.js
+++ b/stories/Table.js
@@ -5,6 +5,8 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import Table from '../src/components/Table/Table';
 
+import style from './style.scss';
+
 const headerData = [
   { label: 'First name', key: 'firstname' },
   { label: 'Last name', key: 'lastname' },
@@ -216,6 +218,37 @@ storiesOf('Table', module).add('with condensed column', () => {
       empty={false}
       emptyText="The table is empty."
       headerData={hd}
+      items={items}
+      loading={false}
+    />
+  );
+});
+
+storiesOf('Table', module).add('with a styled rows and cols', () => {
+  const items = [
+    {
+      firstname: 'Brad',
+      lastname: 'Pitt',
+      age: '45',
+      sex: 'Male',
+      location: 'Beverly Hills',
+      cellClassName: style.tableCellRed,
+    },
+    {
+      firstname: 'Jennifer',
+      lastname: 'Lawrence',
+      age: '26',
+      sex: 'Female',
+      location: 'NYC',
+      rowClassName: style.tableRowFaded,
+    },
+  ];
+
+  return (
+    <Table
+      empty={false}
+      emptyText="The table is empty."
+      headerData={headerData}
       items={items}
       loading={false}
     />

--- a/stories/Table.js
+++ b/stories/Table.js
@@ -231,7 +231,7 @@ storiesOf('Table', module).add('with styled rows', () => {
       lastname: 'Pitt',
       age: '45',
       sex: 'Male',
-      location: 'Beverly Hills'
+      location: 'Beverly Hills',
     },
     {
       firstname: 'Jennifer',

--- a/stories/style.scss
+++ b/stories/style.scss
@@ -1,3 +1,12 @@
 .greenDotLoader {
   background-color: #0f0 !important;
 }
+
+.tableRowFaded {
+  background: rgba(0, 0, 255, 0.35) !important;
+  color: #f3f3f3;
+}
+
+.tableCellRed {
+  background-color: #f00;
+}

--- a/stories/style.scss
+++ b/stories/style.scss
@@ -6,7 +6,3 @@
   background: rgba(0, 0, 255, 0.35) !important;
   color: #f3f3f3;
 }
-
-.tableCellRed {
-  background-color: #f00;
-}


### PR DESCRIPTION
This allows specifying a classname as `rowClassName` in the table's item definition:
<img width="1251" alt="Screen Shot 2019-07-17 at 10 12 52" src="https://user-images.githubusercontent.com/679761/61354723-7b9f6c00-a87b-11e9-8725-ba892d66da97.png">
